### PR TITLE
Fix for offset drawing position

### DIFF
--- a/addons/1dollar/1dollar_gesture_recogniser.gd
+++ b/addons/1dollar/1dollar_gesture_recogniser.gd
@@ -83,16 +83,14 @@ func _input(event):
 		if (event.is_action_pressed(inputMapAction)): ## pressed###############################################
 			draw = []
 			pressed = event.pressed
-			position.x = get_viewport().get_mouse_position().x
-			position.y = get_viewport().get_mouse_position().y
+			position = get_local_mouse_position()
 			if particleEffect and (draw.size() < maximumRecPoints):
 				particleNode.set_emitting(true)
 				particleNode.set_position(position)
 		if (event is InputEventMouseMotion && pressed): ## while pressed#################################
 			if (draw.size() < maximumRecPoints):
 				if curInk > 0:
-					position.x = get_viewport().get_mouse_position().x
-					position.y = get_viewport().get_mouse_position().y
+					position = get_local_mouse_position()
 					draw.append(position)
 					if particleEffect:
 						particleNode.set_position(position)

--- a/addons/1dollar/1dollar_gesture_recogniser.gd
+++ b/addons/1dollar/1dollar_gesture_recogniser.gd
@@ -118,7 +118,8 @@ func recogniseDrawnGesture():
 	var recognisedGesture = guestures.recognize(draw)
 	var inkLeft = curInk
 	emit_signal("shapeDetected",recognisedGesture,inkLeft)
-	get_node("gui/status").set_text(str(recognisedGesture," --ink left:",inkLeft)+str(" --draw: ",draw.size()," --gesture lib: ",guestures.Unistrokes.size()))
+	if recording:
+		get_node("gui/status").set_text(str(recognisedGesture," --ink left:",inkLeft)+str(" --draw: ",draw.size()," --gesture lib: ",guestures.Unistrokes.size()))
 
 	drawColShapePolygon(draw)
 	if inkLossRate  == 0:


### PR DESCRIPTION
If the gesture recogniser control is moved then the drawn lines are offset incorrectly. Using local mouse positioning fixes this.

This PR also fixes a crash bug caused by a null access to a label when recording is disabled.

Examples of bugged offset behaviour vs correct behaviour using local mouse position:

<details><summary><strong>Before</strong></summary>

![godot](https://user-images.githubusercontent.com/550176/81999287-9170ef80-964c-11ea-833c-a55574c44cfc.gif)

</details>

<details><summary><strong>After</strong></summary>

![godot2](https://user-images.githubusercontent.com/550176/81999416-e6ad0100-964c-11ea-8be2-b5e55a8cd4c5.gif)

</details>