### PR TITLE
Correct typo "geusters" / "guestures" + restrict drawing to bounds

### DIFF
--- a/addons/1dollar/1dollar_gesture_recogniser.gd
+++ b/addons/1dollar/1dollar_gesture_recogniser.gd
@@ -55,7 +55,7 @@ func _ready():
 		var debugGui = preload("debugGui.tscn").instance()
 		add_child(debugGui)
 		debugGui.set_position(Vector2(get_global_position().x,get_size().y))
-		get_node("gui/addGuester").connect("pressed",self,"_on_addGuester_pressed")
+		get_node("gui/addGesture").connect("pressed",self,"_on_addGesture_pressed")
 		get_node("gui/saveGesturesToJson").connect("pressed",self,"saveGesturesToJsonFile")
 		get_node("gui/status").set_text(str("Loaded ",guestures.Unistrokes.size()," gestures from json library"))
 		get_tree().set_debug_collisions_hint(true)
@@ -128,12 +128,12 @@ func recogniseDrawnGesture():
 
 var savedGestures = []
 var data = {}
-func _on_addGuester_pressed():
+func _on_addGesture_pressed():
 	if (draw.size() > minimumRecPoints) and (draw.size() < maximumRecPoints):
-		var new_guester = preload("unistroke.gd").new(get_node("gui/guester_name").get_text(), draw)
-		guestures.Unistrokes.append(new_guester)	
+		var newGesture = preload("unistroke.gd").new(get_node("gui/gestureName").get_text(), draw)
+		guestures.Unistrokes.append(newGesture)	
 		## store to array that will be written to the json file
-		savedGestures.append([get_node("gui/guester_name").get_text(),var2str(draw)])
+		savedGestures.append([get_node("gui/gestureName").get_text(),var2str(draw)])
 		if recording:
 			print("we have ",savedGestures.size()," gestures so far")
 			get_node("gui/status").set_text(str("ADDED draw: ",draw.size()," uni: ",guestures.Unistrokes.size()," to ram"))
@@ -167,9 +167,9 @@ func loadSavedGesturesFromJson(path):
 		loadedGestures.append(cleanedGestureData)
 		savedGestures.append(gesture)
 
-	for load_guester in loadedGestures:
-		var new_guester = preload("unistroke.gd").new(load_guester[0], load_guester[1])
-		guestures.Unistrokes.append(new_guester)
+	for loadGesture in loadedGestures:
+		var newGesture = preload("unistroke.gd").new(loadGesture[0], loadGesture[1])
+		guestures.Unistrokes.append(newGesture)
 	if recording:print ("Loaded ",loadedGestures.size()," gestures!")
 
 ## can we draw or not - the mouse needs to be inside the area

--- a/addons/1dollar/debugGui.tscn
+++ b/addons/1dollar/debugGui.tscn
@@ -7,29 +7,28 @@ margin_right = 1274.0
 margin_bottom = 695.0
 mouse_filter = 0
 
-[node name="addGuester" type="Button" parent="."]
-margin_right = 86.0
+[node name="addGesture" type="Button" parent="."]
+margin_right = 92.0
 margin_bottom = 24.0
 action_mode = 0
-text = "addGuester"
+text = "Add Gesture"
 
 [node name="saveGesturesToJson" type="Button" parent="."]
-margin_left = 90.0
-margin_right = 131.0
+margin_left = 96.0
+margin_right = 137.0
 margin_bottom = 24.0
 text = "Save"
 
-[node name="guester_name" type="LineEdit" parent="."]
-margin_left = 135.0
-margin_right = 335.0
+[node name="gestureName" type="LineEdit" parent="."]
+margin_left = 141.0
+margin_right = 341.0
 margin_bottom = 24.0
 rect_min_size = Vector2( 200, 0 )
 
 [node name="status" type="Label" parent="."]
-margin_left = 339.0
-margin_right = 457.0
+margin_left = 345.0
+margin_right = 463.0
 margin_bottom = 14.0
 mouse_filter = 1
 size_flags_vertical = 0
 text = "draw something... "
-


### PR DESCRIPTION
Variable name spelling correction, all instances of geuster/guestures corrected to gestures/gesture.

`_on_mouse_enter` and `_on_mouse_exit` hooks moved to the top and `canDraw` referenced in `_process` so drawing is restricted to the rect bounds.